### PR TITLE
Update test.js

### DIFF
--- a/test.js
+++ b/test.js
@@ -39,4 +39,7 @@ if (cluster.isMaster) {
     
     output = vh.hash2b1(Buffer.from('Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234','utf8'));
     console.log(process.pid,'VerusHash2b1 Output', reverseHex(output.toString('hex')), '\n');
+
+    output = vh.hash2b2(Buffer.from('Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234Test1234','utf8'));
+    console.log(process.pid,'VerusHash2b2 Output', reverseHex(output.toString('hex')), '\n');
 }


### PR DESCRIPTION
Add test case for Verushash v2.2 output
`node test.js`
```
30316 'VerusHash1   Output' '2cd709e6569bd706f14a09e62042ddccfa63bd3725b21f35a8c98adbf4151184' '\n'
30316 'VerusHash2   Output' '55cec43b110570481f6d565c3a8bb6ed174956494aeebf4c264283791dbd3ded' '\n'
30316 'VerusHash2b  Output' 'f971af1d4e551e9e71d35c6266fc19a98c6ad0388be1e9979f66921e07b5c9ac' '\n'
30316 'VerusHash2b1 Output' '0ef8b9530ce44a7ffb9b520daf8fcf59d1d22dd1bfa1a26ef4351d51e37071b7' '\n'
30316 'VerusHash2b2 Output' 'ee2a1613d828cc0a39ba977dd20edd33ed30d7e41bbe2697e0912679de6aa830' '\n'
```