### PR TITLE
Add merged mining compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Implementation of the VerushHash V1, V2, V2.1, V2.2 hash algorithm as a node.js 
 
 ## For testing purposes:
 
+    sudo apt install libsodium-dev
     git clone https://github.com/veruscoin/verushash-node
     cd verushash-node
     npm install

--- a/binding.gyp
+++ b/binding.gyp
@@ -27,6 +27,9 @@
             ],
             "defines": [
             ],
+            "libraries": [
+                "-lsodium"
+            ],
             "cflags_cc": [
                 "-std=c++11",
                 "-Wl,--whole-archive",

--- a/verushash.cc
+++ b/verushash.cc
@@ -286,9 +286,11 @@ void verusHashV2b2(const v8::FunctionCallbackInfo<Value>& args) {
                     memset(buff + 4 + 32 + 32 + 32 + 4 + 4, 0, 32); // nNonce
                     memset(solution + 8, 0, 32 + 32);               // hashPrevMMRRoot, hashBlockMMRRoot
                     //printf("info: merged mining %d chains, clearing non-canonical data on hash found\n", numPBaaSHeaders);
-                }
-                else {
-                    //printf("info: merged mining not enabled\n", numPBaaSHeaders);
+                } else {
+                    // invalid share, pbaas activated must be pbaas mining capatible
+                    memset(result, 0xff, 32);
+                    args.GetReturnValue().Set(Nan::NewBuffer(result, 32).ToLocalChecked());
+                    return;
                 }
             } else {
                 //printf("info: merged mining %d chains, non-canonical data pre-cleared\n", numPBaaSHeaders);

--- a/verushash.cc
+++ b/verushash.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "crypto/verus_hash.h"
+#include "sodium.h"
 
 using namespace v8;
 
@@ -186,6 +187,27 @@ void verusHashV2b1(const v8::FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().Set(Nan::NewBuffer(result, 32).ToLocalChecked());
 }
 
+const unsigned char BLAKE2Bpersonal[crypto_generichash_blake2b_PERSONALBYTES] = { 'V','e','r','u','s','D','e','f','a','u','l','t','H','a','s','h' };
+uint256 blake2b_hash(unsigned char* data, unsigned long long length)
+{
+    const unsigned char* personal = BLAKE2Bpersonal;
+    crypto_generichash_blake2b_state state;
+    uint256 result;
+    if (crypto_generichash_blake2b_init_salt_personal(
+        &state,
+        NULL, 0, // No key.
+        32,
+        NULL,    // No salt.
+        personal) == 0) {
+        crypto_generichash_blake2b_update(&state, data, length);
+        if (crypto_generichash_blake2b_final(&state, reinterpret_cast<unsigned char*>(&result), crypto_generichash_blake2b_BYTES) == 0) {
+            return result;
+        }
+    }
+    result.SetNull();
+    return result;
+}
+
 void verusHashV2b2(const v8::FunctionCallbackInfo<Value>& args) {
     Isolate* isolate = Isolate::GetCurrent();
     HandleScope scope(isolate);
@@ -210,12 +232,63 @@ void verusHashV2b2(const v8::FunctionCallbackInfo<Value>& args) {
         return;
     }
 
-    const char *buff = node::Buffer::Data(buffer);
-
-    char *result = new char[32];
+    char *buff = node::Buffer::Data(buffer);
+    char* result = new char[32];
     
     if (initialized == false) {
         initialize();
+    }
+
+    // detect pbaas, validate and clear non-conical data if needed
+    char* solution = (buff + 140 + 3);
+    unsigned int sol_ver = ((solution[0]) + (solution[1] << 8) + (solution[2] << 16) + (solution[3] << 24));
+    if (sol_ver > 6) {
+        const uint8_t descrBits = solution[4];
+        const uint8_t numPBaaSHeaders = solution[5];
+        const uint16_t extraSpace = solution[6] | ((uint16_t)(solution[7]) << 8);
+        const uint32_t soln_header_size = 4 + 1 + 1 + 2 + 32 + 32; // version, descr, numPBaas, extraSpace, hashPrevMMRroot, hashBlockMMRroot
+        const uint32_t soln_pbaas_cid_size = 20;   // hash160
+        const uint32_t soln_pbaas_prehash_sz = 32; // pre header hash blake2b
+
+        unsigned char preHeader[32 + 32 + 32 + 32 + 4 + 32 + 32];
+        memset(&preHeader[0], 0, sizeof(preHeader));
+
+        // copy non-conical items from block header
+        memcpy(&preHeader[  0], buff + 4, 32);           // hashPrevBlock
+        memcpy(&preHeader[ 32], buff + 4 + 32, 32);      // hashMerkleRoot
+        memcpy(&preHeader[ 64], buff + 4 + 32 + 32, 32); // hashFinalSaplingRoot
+        memset(&preHeader[ 96], 0, 32); // nNonce (if nonce changes must update preHeaderHash in solution)
+        memcpy(&preHeader[128], buff + 4 + 32 + 32 + 32 + 4, 4); // nbits
+        memcpy(&preHeader[132], solution + 8, 32 + 32);  // hashPrevMMRRoot, hashPrevMMRRoot
+
+        // detect if merged mining is present and clear non-conical data (if needed)
+        int matched_zeros = 0;
+        for (int i = 0; i < sizeof(preHeader); i++) {
+            if (preHeader[i] == 0) { matched_zeros++; }
+        }
+        // if the data has already been cleared of non-conical data, must be merged mining
+        if (matched_zeros != sizeof(preHeader)) {
+            // detect merged mining by looking for preHeaderHash (blake2b) in first pbaas chain definition
+            int matched_hashes = 0;
+            uint256 preHeaderHash = blake2b_hash(&preHeader[0], sizeof(preHeader));
+            if (!preHeaderHash.IsNull()) {
+                if (memcmp((unsigned char*)&preHeaderHash,
+                    &solution[soln_header_size + soln_pbaas_cid_size],
+                    soln_pbaas_prehash_sz) == 0) {
+                    matched_hashes++;
+                }
+            }
+            // clear non-conical data for pbaas merge mining
+            if (matched_hashes > 0) {
+                memset(buff + 4, 0, 32 + 32 + 32);              // hashPrevBlock, hashMerkleRoot, hashFinalSaplingRoot
+                memset(buff + 4 + 32 + 32 + 32 + 4, 0, 4);      // nBits
+                memset(buff + 4 + 32 + 32 + 32 + 4 + 4, 0, 32); // nNonce
+                memset(solution + 8, 0, 32 + 32);               // hashPrevMMRRoot, hashBlockMMRRoot
+                //printf("info: merged mining %d chains, clearing conical data on hash found\n", numPBaaSHeaders);
+            }
+        } else {
+            //printf("info: merged mining %d chains, conical data is cleared\n", numPBaaSHeaders);
+        }
     }
 
     vh2b2->Reset();

--- a/verushash.cc
+++ b/verushash.cc
@@ -239,7 +239,7 @@ void verusHashV2b2(const v8::FunctionCallbackInfo<Value>& args) {
         initialize();
     }
 
-    // detect pbaas, validate and clear non-conical data if needed
+    // detect pbaas, validate and clear non-canonical data if needed
     char* solution = (buff + 140 + 3);
     unsigned int sol_ver = ((solution[0]) + (solution[1] << 8) + (solution[2] << 16) + (solution[3] << 24));
     if (sol_ver > 6) {
@@ -253,7 +253,7 @@ void verusHashV2b2(const v8::FunctionCallbackInfo<Value>& args) {
         if (numPBaaSHeaders > 0) {
             unsigned char preHeader[32 + 32 + 32 + 32 + 4 + 32 + 32] = { 0, };
 
-            // copy non-conical items from block header
+            // copy non-canonical items from block header
             memcpy(&preHeader[0], buff + 4, 32);           // hashPrevBlock
             memcpy(&preHeader[32], buff + 4 + 32, 32);      // hashMerkleRoot
             memcpy(&preHeader[64], buff + 4 + 32 + 32, 32); // hashFinalSaplingRoot
@@ -261,12 +261,13 @@ void verusHashV2b2(const v8::FunctionCallbackInfo<Value>& args) {
             memcpy(&preHeader[128], buff + 4 + 32 + 32 + 32 + 4, 4); // nbits
             memcpy(&preHeader[132], solution + 8, 32 + 32);  // hashPrevMMRRoot, hashPrevMMRRoot
 
-            // detect if merged mining is present and clear non-conical data (if needed)
+            // detect if merged mining is present and clear non-canonical data (if needed)
             int matched_zeros = 0;
             for (int i = 0; i < sizeof(preHeader); i++) {
                 if (preHeader[i] == 0) { matched_zeros++; }
             }
-            // if the data has already been cleared of non-conical data, just continue along
+
+            // if the data has already been cleared of non-canonical data, just continue along
             if (matched_zeros != sizeof(preHeader)) {
                 // detect merged mining by looking for preHeaderHash (blake2b) in first pbaas chain definition
                 int matched_hashes = 0;
@@ -278,20 +279,19 @@ void verusHashV2b2(const v8::FunctionCallbackInfo<Value>& args) {
                         matched_hashes++;
                     }
                 }
-                // clear non-conical data for pbaas merge mining
+                // clear non-canonical data for pbaas merge mining
                 if (matched_hashes > 0) {
                     memset(buff + 4, 0, 32 + 32 + 32);              // hashPrevBlock, hashMerkleRoot, hashFinalSaplingRoot
                     memset(buff + 4 + 32 + 32 + 32 + 4, 0, 4);      // nBits
                     memset(buff + 4 + 32 + 32 + 32 + 4 + 4, 0, 32); // nNonce
                     memset(solution + 8, 0, 32 + 32);               // hashPrevMMRRoot, hashBlockMMRRoot
-
-                    //printf("info: merged mining %d chains, clearing non-conical data on hash found\n", numPBaaSHeaders);
+                    //printf("info: merged mining %d chains, clearing non-canonical data on hash found\n", numPBaaSHeaders);
                 }
                 else {
                     //printf("info: merged mining not enabled\n", numPBaaSHeaders);
                 }
             } else {
-                //printf("info: merged mining %d chains, non-conical data pre-cleared\n", numPBaaSHeaders);
+                //printf("info: merged mining %d chains, non-canonical data pre-cleared\n", numPBaaSHeaders);
             }
         }
     }


### PR DESCRIPTION
Note, this change requires libsodium-dev package to be installed or node-gyp will fail to build the module.

Support hashing blocks properly for pbaas merged mining support:
- Activates on pbaas solution version 7
- Detects pbaas merged mine blocks by validating presence of blake2b preheader hash in solution (rejecting if needed)
- Clears non-canonical data from block before hashing merge mined blocks